### PR TITLE
fix: use standalone mirror of 'invariant' module

### DIFF
--- a/checker.js
+++ b/checker.js
@@ -2,7 +2,7 @@
 // and adapted to return an object of errors instead of console.warning
 
 const PropTypes = require('prop-types')
-const invariant = require('fbjs/lib/invariant')
+const invariant = require('invariant')
 const ReactPropTypesSecret = require('prop-types/lib/ReactPropTypesSecret')
 
 function checkPropTypes(typeSpecs, values, location = 'prop', componentName = 'Component', getStack) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepublish": "yarn test"
   },
   "dependencies": {
+    "invariant": "^2.2.4",
     "prop-types": "^15.6.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,6 +109,13 @@ inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
+
 is-stream@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"


### PR DESCRIPTION
This module relies on `prop-types` bringing in the `fbjs` module as a dependency, to make use of its invariant functionality.

Recent versions of `prop-types` have had this [refactored out](https://github.com/facebook/prop-types/commit/07d1b47353c73eb7bdded80ac13d7ca082935d9d#diff-b647914c17a3b18d11debbb4da8a3c54), causing this module to fail when using `prop-types@15.7.2` or later.

This PR adds `invariant`, a  standalone mirror of the removed functionality, which gets everything working as expected again.

In the future, it might be worth considering updating to incorporate the most recent version of `prop-types/checkPropTypes.js`.